### PR TITLE
Add draft for story 1.2 preview session control

### DIFF
--- a/docs/stories/1.2.preview-session-control.md
+++ b/docs/stories/1.2.preview-session-control.md
@@ -1,0 +1,58 @@
+# Story 1.2: Preview Session Control
+
+## Status
+Draft
+
+## Story
+As a user,
+I want the preview window to react to my review decisions in real time,
+so that I can approve, edit, or abort a run with confidence before any submission happens.
+
+## Context Source
+- Source Document: [Epic 1 — Foundation & Review UI](../prd/epic-1-foundation-review-ui.md#story-12-—-preview-server-skeleton)
+- Enhancement Type: Feature hardening of preview review loop
+- Existing System Impact: Extends preview server skeleton and UI to handle interactive state and decision signalling without yet touching artifact persistence or live automation
+
+## Acceptance Criteria
+1. `POST /api/run/preview` creates an in-memory review session with a generated `runId`, stores the provided screenshot URL, summary, dry-run flag, and returns the payload defined in the REST contract including `status: "review"`. [Source: docs/architecture/api-specification-rest.md#api-specification-rest][Source: docs/architecture/data-models.md#run]
+2. `GET /api/run/{id}` returns the latest session snapshot containing `status`, `preview`, and decision metadata (`approved`, `edits`, `abortedAt`) so the UI can refresh after actions. [Source: docs/architecture/backend-architecture.md#service-architecture-traditional-server]
+3. `POST /api/run/{id}/approve`, `/edit`, and `/abort` update the session state atomically, enqueue a corresponding decision event for the CLI orchestrator, and return JSON with the updated state while honouring the dry-run guardrail (no downstream submission trigger yet). [Source: docs/architecture/components.md#preview-server-bff][Source: docs/architecture/core-workflows.md#review-first-apply-sequence]
+4. `GET /api/run/{id}/updates?since=<timestamp>` returns an ordered list of session events (created, approved, edit-requested, edit-applied, aborted) filtered by the `since` cursor so the UI can poll without missing transitions. [Source: docs/architecture/api-specification-rest.md#api-specification-rest][Source: docs/architecture/monitoring-and-observability.md]
+5. UI polls the updates endpoint on an interval, reflects decision state (e.g., disabled buttons once approved/aborted, latest edit text), and shows a persistent dry-run indicator sourced from the session payload. Keyboard shortcuts continue to work against the updated handlers. [Source: docs/architecture/frontend-architecture.md#component-architecture][Source: docs/prd/requirements.md#functional-fr]
+
+## Tasks / Subtasks
+- [ ] Implement preview session manager for FastAPI service (AC: 1-4)
+  - [ ] Create a `PreviewSessionManager` with thread-safe storage, event queues, and timestamped event list. [Source: docs/architecture/backend-architecture.md#service-architecture-traditional-server]
+  - [ ] Generate RFC 4122 run IDs and normalise timestamps in ISO 8601 UTC. [Source: docs/architecture/data-models.md#run]
+  - [ ] Ensure dry-run flag is persisted and exposed on every response without triggering downstream automation. [Source: docs/architecture/core-workflows.md#review-first-apply-sequence]
+- [ ] Expand FastAPI routes to use the session manager (AC: 1-4)
+  - [ ] `POST /api/run/preview` validates payload, seeds initial session event, and returns contract-compliant JSON (status `review`). [Source: docs/architecture/api-specification-rest.md#api-specification-rest]
+  - [ ] `GET /api/run/{id}` and `/updates` return 404 via `ApiError` envelope when a session is missing. [Source: docs/architecture/api-specification-rest.md#api-specification-rest]
+  - [ ] Decision endpoints push events into a dedicated queue for CLI consumers and mark one-shot transitions (approve/abort) idempotent. [Source: docs/architecture/components.md#preview-server-bff]
+- [ ] Update CLI preview runner integration (AC: 3)
+  - [ ] Expose a synchronous helper `wait_for_decision(run_id)` that blocks on the queue with timeout/backoff for review-mode flows. [Source: docs/architecture/core-workflows.md#review-first-apply-sequence]
+  - [ ] Surface dry-run simulation messaging in CLI logs while waiting for decisions. [Source: docs/prd/requirements.md#non-functional-nfr]
+- [ ] Enhance React preview UI behaviour (AC: 5)
+  - [ ] Add polling hook hitting `/api/run/{id}/updates` on a 1s cadence with exponential backoff after inactivity. [Source: docs/architecture/frontend-architecture.md#state-management-architecture]
+  - [ ] Disable or relabel controls after terminal states (approved/aborted), showing the decision summary toast. [Source: docs/prd/user-interface-design-goals.md]
+  - [ ] Display latest edit text in the dialog on re-open and keep keyboard shortcuts mapped after handler updates. [Source: docs/architecture/frontend-architecture.md#component-architecture]
+- [ ] Testing (AC: 1-5)
+  - [ ] Pytest coverage for session manager, API routes, and decision queue semantics including dry-run guardrail. [Source: docs/architecture/testing-strategy.md#backend-api-test-py]
+  - [ ] Vitest + RTL coverage for polling hook, button disablement, and shortcut regression. [Source: docs/architecture/testing-strategy.md#frontend-component-test-vitest-+-rtl]
+  - [ ] Optional integration test using httpx AsyncClient to simulate CLI wait + UI decision handshake. [Source: docs/architecture/testing-strategy.md#testing-pyramid]
+
+## Dev Notes
+- Prefer dependency-free concurrency primitives (`asyncio.Queue` or `queue.Queue`) for cross-thread signalling; align with Windows-safe patterns. [Source: docs/architecture/development-workflow.md#environment-configuration]
+- Keep session storage in-memory for now; persistence to filesystem will arrive in Story 1.4. Document TODO references to avoid duplicate work. [Source: docs/prd/epic-1-foundation-review-ui.md#story-14-—-run-store-—-redacted-logging-skeleton]
+- Response envelopes must follow the `ApiError`/success schema; include `requestId` in logs for tracing. [Source: docs/architecture/api-specification-rest.md#api-specification-rest]
+- UI polling interval should be resilient to window focus changes and stop once a terminal decision event is observed. [Source: docs/architecture/frontend-architecture.md#state-management-architecture]
+
+### Testing
+- Backend: `pytest apps/preview/tests` covering session lifecycle, idempotent transitions, and dry-run enforcement. [Source: docs/architecture/testing-strategy.md#backend-api-test-py]
+- Frontend: `npm run test -- --runInBand` (Vitest) verifying polling hook behaviour and button states post decision. [Source: docs/architecture/testing-strategy.md#frontend-component-test-vitest-+-rtl]
+- Optional: Playwright smoke to confirm disabled controls after approval/abort under `http://localhost:4950/ui`. [Source: docs/architecture/testing-strategy.md#e2e-test-playwright-+-optional-local]
+
+## Change Log
+| Date | Version | Description | Author |
+| ---- | ------- | ----------- | ------ |
+| 2025-09-27 | 0.1 | Initial draft defining preview session control scope and acceptance criteria | Scrum Master |


### PR DESCRIPTION
## Summary
- add a draft story outlining preview session control scope for Story 1.2
- document acceptance criteria, tasks, and dev notes for backend and UI review loop hardening

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6c84a64448324b319ce674bddf2db