### PR TITLE
docs: add draft for story 1.3 profiles schema commands

### DIFF
--- a/docs/stories/1.3.profiles-schema-commands.md
+++ b/docs/stories/1.3.profiles-schema-commands.md
@@ -1,0 +1,98 @@
+# Story 1.3: Profiles Schema & Commands
+
+## Status
+Draft
+
+## Story
+As a user,
+I want to create and validate role profiles,
+so that each application uses the correct identity and resume.
+
+## Acceptance Criteria
+1. `profiles new <id>` writes `data/profiles/<id>.yaml` using a template.
+2. Schema includes identity, Q&A, model overrides, `documents.resume_path`.
+3. `profiles validate <id>` checks YAML and resume presence at `data/resumes/<id>/resume.pdf`.
+4. `profiles list` shows available profiles and their status.
+5. Profile switching persists for the current session.
+
+## Tasks / Subtasks
+- [ ] Implement profile schema models and loader (AC: 2, 3) [Source: docs/architecture/data-models.md#profile][Source: docs/prd/technical-assumptions.md#testing-requirements-unit--integration--ui--a11y]
+  - [ ] Add a `ProfileConfig` pydantic model representing identity, documents.resume_path, qa_overrides, model/browser overrides, and user data dir metadata in `apps/cli/profiles.py`. [Source: docs/architecture/data-models.md#profile][Source: docs/temp/brief.md#proposed-solution]
+  - [ ] Provide YAML parsing helpers that resolve paths relative to `data/profiles/` and apply precedence with global settings via `Settings.load`. [Source: docs/prd/requirements.md#functional-fr]
+  - [ ] Surface validation errors with structured messages (`code`, `message`, `details`) aligned to logging standards. [Source: docs/architecture/coding-standards.md#critical-fullstack-rules]
+- [ ] Scaffold `profiles new` CLI flow (AC: 1, 2) [Source: docs/prd/epic-1-foundation-review-ui.md#story-13--profiles-schema--commands]
+  - [ ] Generate `data/profiles/<id>.yaml` from a Jinja-free string template including placeholders for identity/contact, qa_overrides, documents.resume_path, and model overrides; skip overwrite unless `--force`. [Source: docs/prd/requirements.md#functional-fr][Source: docs/temp/brief.md#proposed-solution]
+  - [ ] Ensure the command also creates `data/resumes/<id>/` and `.local/browser/profiles/<id>/` directories if absent. [Source: docs/architecture/unified-project-structure.md][Source: docs/prd/requirements.md#functional-fr]
+  - [ ] Document template fields in CLI output (e.g., resume path reminder, Q&A section usage). [Source: docs/prd/goals-and-background-context.md]
+- [ ] Implement validation & status reporting commands (AC: 3, 4, 5) [Source: docs/prd/epic-1-foundation-review-ui.md#story-13--profiles-schema--commands]
+  - [ ] Add `profiles validate <id>` to load YAML via `ProfileConfig`, verify `data/resumes/<id>/resume.pdf` exists, and emit actionable errors. [Source: docs/prd/requirements.md#functional-fr]
+  - [ ] Enhance `profiles list` to show `id`, validity flag, resume status, and whether it is the active profile. [Source: docs/prd/goals-and-background-context.md][Source: docs/prd/requirements.md#functional-fr]
+  - [ ] Introduce `profiles use <id>` (or equivalent) that persists the active profile for the current CLI session (e.g., `.local/state/active-profile.json`) and update `Settings.load` to read it. [Source: docs/prd/requirements.md#functional-fr][Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-23--profile-binding--resume-availability]
+  - [ ] Provide `profiles current` to display the active profile, including resolved resume path and session directory. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-23--profile-binding--resume-availability]
+- [ ] Update runtime scaffolding and documentation (AC: 1-5) [Source: docs/architecture/unified-project-structure.md]
+  - [ ] Extend `ensure_runtime_dirs` to provision `data/resumes` and `.local/browser/profiles`. [Source: docs/architecture/unified-project-structure.md][Source: docs/prd/requirements.md#functional-fr]
+  - [ ] Refresh README quickstart snippets to mention profile commands and expected directory layout. [Source: docs/prd/requirements.md#functional-fr]
+  - [ ] Add migration note for existing users (create `data/resumes/<id>` folders manually if upgrading). [Source: docs/prd/goals-and-background-context.md]
+- [ ] Add automated tests & fixtures (AC: 1-5) [Source: docs/architecture/testing-strategy.md#test-organization]
+  - [ ] Pytest coverage for `profiles new`, `validate`, `use`, and `list` using `tmp_path` to isolate filesystem side effects. [Source: docs/architecture/testing-strategy.md#backend-api-test-py]
+  - [ ] Contract test confirming generated YAML matches expected schema keys and defaults (pydantic `.model_dump`). [Source: docs/prd/technical-assumptions.md#testing-requirements-unit--integration--ui--a11y]
+  - [ ] Snapshot or structured assertion ensuring list output sorts deterministically and highlights the active profile. [Source: docs/prd/requirements.md#functional-fr]
+
+## Dev Notes
+- **Profile contract & storage**
+  - Profile YAML lives under `data/profiles/<id>.yaml` with resume assets at `data/resumes/<id>/resume.pdf`; runtime must create these folders on demand. [Source: docs/architecture/unified-project-structure.md][Source: docs/prd/requirements.md#functional-fr]
+  - Schema fields are defined in the architecture data model: `id`, `displayName`, `documents.resumePath`, optional `qaOverrides`, and `userDataDir` metadata for browser reuse. [Source: docs/architecture/data-models.md#profile]
+  - Profiles also capture identity/contact info, portfolio links, and narrative Q&A banks per the product brief; structure them under `identity`, `qa_overrides`, `links`, and `model_overrides`. [Source: docs/temp/brief.md#proposed-solution][Source: docs/prd/goals-and-background-context.md]
+- **CLI integration**
+  - Extend `apps/cli/main.py` `profiles_app` subcommands to delegate to a dedicated `ProfileService` in `apps/cli/profiles.py` for reuse by future apply flows. [Source: docs/architecture/components.md#cli-orchestrator]
+  - `profiles new` should refuse to overwrite existing YAML unless `--force`, print the created path, and remind the user to place `resume.pdf` under `data/resumes/<id>/`. [Source: docs/prd/epic-1-foundation-review-ui.md#story-13--profiles-schema--commands]
+  - Persist the active profile in a small JSON marker (e.g., `.local/state/active-profile.json`) so subsequent CLI invocations pick it up via `Settings.load`. [Source: docs/prd/requirements.md#functional-fr][Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-23--profile-binding--resume-availability]
+- **Validation & error handling**
+  - Use `pydantic` for schema enforcement and provide helpful error messages referencing the offending key/value. [Source: docs/prd/technical-assumptions.md#testing-requirements-unit--integration--ui--a11y]
+  - Resume validation must check for a PDF at `data/resumes/<id>/resume.pdf` and surface actionable remediation steps in CLI output (e.g., “Add resume.pdf to …”). [Source: docs/prd/epic-1-foundation-review-ui.md#story-13--profiles-schema--commands][Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-23--profile-binding--resume-availability]
+  - Align error/event logging with `log_event` helpers to maintain redaction-ready JSON logs. [Source: docs/architecture/coding-standards.md#critical-fullstack-rules]
+- **Template blueprint**
+  - Provide a commented YAML skeleton similar to:
+    ```yaml
+    id: frontend-dev
+    display_name: Frontend Developer
+    identity:
+      full_name: ""
+      email: ""
+      phone: ""
+      location: ""
+      portfolio: []
+    documents:
+      resume_path: data/resumes/frontend-dev/resume.pdf
+    model_overrides:
+      llm: deepseek/deepseek-chat-v3.1:free
+    qa_overrides:
+      "Are you legally authorized to work in the US?": "Yes"
+    user_data_dir: .local/browser/profiles/frontend-dev
+    ```
+    Developers can expand sections, but defaults must satisfy the schema keys. [Source: docs/prd/requirements.md#functional-fr][Source: docs/temp/brief.md#proposed-solution]
+- **Future integration hooks**
+  - `ProfileConfig` should expose computed properties for resume path and session directory to support Epic 2’s browser binding without refactoring. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-23--profile-binding--resume-availability]
+  - Prepare to surface profile metadata to the Browser-Use wrapper (identity fields, QA answers, overrides) once automation begins. [Source: docs/prd/epic-3-simplyhired-quick-apply-automation.md#story-31--identity--eligibility-form-fill]
+
+### Testing
+- Place CLI tests under `core/tests/` using pytest with `tmp_path` fixtures to isolate filesystem effects per architecture testing strategy. [Source: docs/architecture/testing-strategy.md#backend-api-test-py]
+- Validate schema contracts via `ProfileConfig.model_dump()` comparisons and missing-field error cases. [Source: docs/prd/technical-assumptions.md#testing-requirements-unit--integration--ui--a11y]
+- Add a smoke test ensuring `profiles use` updates the active profile marker and `Settings.load` reflects it, preventing regression when apply flow reads settings. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-23--profile-binding--resume-availability]
+
+## Change Log
+| Date | Version | Description | Author |
+| ---- | ------- | ----------- | ------ |
+| 2025-09-26 | 0.1 | Initial draft prepared after reviewing Epic 1 Story 1.3 requirements and architecture docs. | Scrum Master |
+
+## Dev Agent Record
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List
+
+## QA Results
+


### PR DESCRIPTION
## Summary
- add the Story 1.3 draft describing the profiles schema and CLI workflows
- document tasks, developer notes, and testing guidance for profile creation and validation

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6cc97e3bc8324ab229ad2dcecb906