### PR TITLE
Add draft story 2.4 search page readiness detection

### DIFF
--- a/docs/stories/2.4.search-page-readiness-detection.md
+++ b/docs/stories/2.4.search-page-readiness-detection.md
@@ -1,0 +1,76 @@
+# Story 2.4 — Search Page Readiness Detection
+
+## Status
+Draft 0.1 — Pending dev grooming
+
+## Story
+As a developer,
+I want heuristics to confirm the SimplyHired search layout is ready,
+so that later steps can rely on a stable structure.
+
+## Context Source
+- Source Document: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-24-search-page-readiness-detection
+- Enhancement Type: Browser automation reliability hardening (layout readiness heuristics)
+- Existing System Impact: Extends `apply open` flow by layering DOM readiness checks, telemetry, and snapshot capture on top of the Browser-Use controller introduced in Stories 2.1–2.3 while keeping guardrails, profile binding, and run-store contracts intact.
+
+## Acceptance Criteria
+1. After `python app.py apply open <search_url>` launches Browser-Use, the CLI polls the active tab until it detects the SimplyHired left rail with ≥10 job-card list items (each exposing role/title metadata) **and** the right-hand detail pane container; on success it emits a structured `browser.search.SEARCH_READY` event (stdout + actions.log) and returns the readiness payload alongside the existing session JSON. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-24-search-page-readiness-detection][Source: docs/prd/requirements.md#functional-fr][Source: apps/browser/controller.py]
+2. Readiness checks apply a layered wait strategy (initial `wait_for_idle`, explicit spinner/placeholder polling up to a configurable timeout, and a final DOM snapshot) before declaring success; telemetry records elapsed time and selectors satisfied, and dry-run mode continues to skip network calls while still exercising the readiness routine against stored HTML. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-24-search-page-readiness-detection][Source: docs/architecture/components.md#browser-use-controller][Source: apps/cli/main.py]
+3. Selector heuristics are sourced from a JSON/YAML map under `sites/simplyhired/` that enumerates supported A/B variants (CSS/XPath selectors, min-count expectations); loading failures surface actionable `ApiError` messages, and the CLI exposes a `--selectors-path` override for local experiments without code changes. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-24-search-page-readiness-detection][Source: docs/architecture/high-level-architecture.md][Source: docs/prd/requirements.md#functional-fr]
+4. If readiness fails after one backoff+retry attempt, the CLI emits `browser.search.SEARCH_UNREADY` with failure context (selectors missing, elapsed time), persists an HTML snapshot and PNG screenshot under the active run directory, and returns a structured error payload without crashing the process; guardrail and profile-binding telemetry remain unchanged from Story 2.3. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-24-search-page-readiness-detection][Source: docs/prd/requirements.md#non-functional-nfr][Source: apps/cli/run_store.py][Source: apps/cli/utils.py]
+5. Regression coverage exercises at least three stored SimplyHired HTML fixtures (baseline, pagination variant, sponsored-card variant) to assert readiness success/failure branches, ensures telemetry redaction, and verifies that existing `apply open` outputs (profile binding, guardrails, status) remain backwards compatible. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-24-search-page-readiness-detection][Source: docs/architecture/testing-strategy.md][Source: core/tests/test_apply_open.py]
+
+## Tasks / Subtasks
+- [ ] Introduce a `SearchReadinessDetector` (e.g., `apps/browser/readiness.py`) that wraps Browser-Use DOM inspection utilities, loads selector variants from disk, and exposes `await_ready(page)` returning success metadata or structured failure reasons. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-24-search-page-readiness-detection][Source: docs/architecture/components.md#browser-use-controller]
+  - [ ] Support dependency injection for DOM accessor functions so unit tests can replay stored HTML fixtures without launching Chrome. [Source: docs/architecture/testing-strategy.md]
+- [ ] Extend `BrowserUseController` with a `detect_search_readiness(url, selectors, *, timeout)` helper that coordinates `wait_for_idle`, delegates to `SearchReadinessDetector`, and records telemetry (`SEARCH_READY`/`SEARCH_UNREADY`). [Source: apps/browser/controller.py][Source: docs/prd/requirements.md#functional-fr]
+- [ ] Update `apply open` to invoke readiness detection after successful navigation, emit CLI output with a new `search` block (`status`, `elapsedMs`, `variant`, `retryCount`, asset paths), and honor a `--selectors-path` option with config/profile precedence. [Source: apps/cli/main.py][Source: docs/prd/requirements.md#functional-fr]
+  - [ ] Ensure dry-run mode pulls fixtures from `sites/simplyhired/fixtures/` (or a configured path) instead of live DOM, keeping no-network guarantees from Story 1.5. [Source: docs/stories/1.5.dry-run-demo-flow.md]
+- [ ] Enhance `RunStore` to persist readiness artifacts (`search-ready.json`, `search-unready.html`, `search-unready.png`) with redaction-safe metadata, and expose helpers so future stories can reuse captured DOM. [Source: apps/cli/run_store.py][Source: docs/architecture/high-level-architecture.md]
+- [ ] Expand telemetry/logging utilities with dedicated event helpers (`browser.search.SEARCH_READY`, `browser.search.SEARCH_UNREADY`) that redact selectors but include variant keys and elapsed timings. [Source: apps/cli/utils.py][Source: docs/architecture/monitoring-and-observability.md]
+- [ ] Add automated tests:
+  - [ ] Fixture-driven unit tests for `SearchReadinessDetector` covering baseline success, alternate layout, and failure after retry. [Source: docs/architecture/testing-strategy.md][Source: core/tests/test_apply_open.py]
+  - [ ] CLI integration test verifying `apply open` returns readiness data, emits telemetry, preserves backwards-compatible fields, and captures artifacts when forced to fail. [Source: docs/prd/requirements.md#functional-fr][Source: core/tests/test_apply_open.py]
+  - [ ] Regression test ensuring guardrail, profile binding, and resume validation behaviour from Stories 2.1–2.3 remain unchanged when readiness detection is toggled on/off. [Source: docs/stories/2.3.profile-binding-resume-availability.md]
+- [ ] Document selector map format and readiness workflow in `docs/prd/index.md` and README “Browser Automation” section; update architecture components page with the new detector module. [Source: docs/prd/index.md][Source: README.md][Source: docs/architecture/components.md]
+
+## Implementation Outline (Draft)
+- Load selector variants from `sites/simplyhired/search_readiness.json` (configurable override). Normalize into a structured data class describing left-rail item selector, minimum counts, right-pane selector, spinner selectors, and optional variant tags.
+- After `BrowserUseController.open_url`, execute `wait_for_idle` then poll the page (via Browser-Use DOM APIs or Playwright) until selectors match or timeout; on each attempt, capture DOM state if debugging enabled. Retry once with exponential backoff if selectors are missing before surfacing failure.
+- Surface readiness telemetry through `log_event`, including `elapsedMs`, selected variant key, retry count, and sanitized selectors. Inject the readiness payload into CLI JSON output and run context metadata so downstream automation can reuse the state.
+- When readiness fails, capture HTML (`page.content()`), screenshot (`page.screenshot()`), and store them using `RunStore`; include artifact paths in the CLI payload and structured error to aid debugging without exposing PII in logs.
+- Provide dry-run hooks that bypass live Browser-Use, instead feeding fixtures into `SearchReadinessDetector` to keep deterministic local testing.
+
+## Dev Notes
+- **Selector governance:** Keep selectors and thresholds data-driven in `sites/simplyhired/` so operators can update layout variants without modifying Python; validate schema on load and surface friendly errors. [Source: docs/prd/requirements.md#functional-fr][Source: docs/architecture/high-level-architecture.md]
+- **Telemetry hygiene:** Reuse `log_event` for readiness events, redacting raw selector strings while logging variant identifiers and timings for observability. [Source: apps/cli/utils.py][Source: docs/architecture/monitoring-and-observability.md]
+- **Dry-run parity:** Ensure the demo/dry-run flows (Stories 1.5 & 2.1) still avoid outbound network traffic by short-circuiting Browser-Use navigation and feeding stored fixtures through the detector. [Source: docs/stories/1.5.dry-run-demo-flow.md][Source: docs/stories/2.1.browser-use-wrapper-initialization.md]
+- **Future extensibility:** Structure the detector so Epic 3 can plug in pagination handling and Quick Apply discovery after readiness confirmation without duplicating DOM polling logic. [Source: docs/prd/epic-3-simplyhired-quick-apply-automation.md]
+
+### Testing Expectations
+- Unit tests mock Browser-Use DOM access and replay HTML fixtures to assert variant detection, timeout/backoff behaviour, and telemetry redaction. [Source: docs/architecture/testing-strategy.md]
+- Integration tests invoke `apply open` with stubbed Browser-Use client to validate readiness payloads, artifact capture, CLI flags (`--selectors-path`), and backwards-compatible outputs. [Source: core/tests/test_apply_open.py]
+- Snapshot/fixture tests confirm HTML/PNG artifacts are written to the active run directory with sanitized filenames and metadata recorded in run context. [Source: apps/cli/run_store.py]
+
+## Change Log
+| Date | Version | Description | Author |
+| ---- | ------- | ----------- | ------ |
+| 2025-10-14 | 0.1 | Initial Scrum Master draft aligning readiness heuristics with Epic 2, PRD, and architecture context. | Scrum Master |
+
+## PO Validation Checklist
+- [x] Story goal and context tie readiness detection to Epic 2 objectives and explain dependencies on prior guardrail/profile work. [Source: docs/prd/epic-2-stealth-browser-wrapper-profiles.md#story-24-search-page-readiness-detection]
+- [x] Acceptance criteria are testable, cite authoritative docs/code, and include regression expectations for existing guardrail/profile flows. [Source: docs/prd/requirements.md#functional-fr][Source: apps/browser/controller.py]
+- [x] Technical guidance names concrete modules (BrowserUse controller, CLI, run store, selector assets) and data-driven selector strategy to guide implementation. [Source: docs/architecture/components.md#browser-use-controller][Source: docs/architecture/high-level-architecture.md]
+- [x] Dependencies and regression risks (dry-run guardrails, profile binding, telemetry redaction) are surfaced in tasks/dev notes to protect existing behaviour. [Source: docs/stories/2.3.profile-binding-resume-availability.md][Source: apps/cli/utils.py]
+- [x] Testing expectations outline fixture-driven unit tests, CLI integration coverage, and artifact assertions needed before dev hand-off. [Source: docs/architecture/testing-strategy.md]
+
+### Validate Story Checklist (PO Sign-off)
+| Category                             | Status | Notes |
+| ------------------------------------ | ------ | ----- |
+| 1. Goal & Context Clarity            | PASS   | Captures Epic intent, ties to Stories 2.1–2.3, and explains readiness value for later automation. |
+| 2. Technical Implementation Guidance | PASS   | Identifies new detector module, controller integration, CLI flag, and run-store updates required. |
+| 3. Reference Effectiveness           | PASS   | Each AC/task references PRD, architecture, or existing code for traceability. |
+| 4. Dependency & Regression Awareness | PASS   | Highlights dry-run guarantees, guardrail telemetry, and profile binding reuse to avoid regressions. |
+| 5. Testing Guidance                  | PASS   | Specifies fixture + integration coverage to validate readiness heuristics and artifact capture. |
+
+**Final Assessment:** READY FOR DEV — Story 2.4 provides sufficient context, acceptance criteria, and guidance for implementation.


### PR DESCRIPTION
## Summary
- add the draft story document for Story 2.4 covering search page readiness heuristics
- outline acceptance criteria, tasks, implementation guidance, and validation checklist tied to Epic 2 context

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d7723134688324962091a6cb9457ac