### PR TITLE
QA review for Story 4.1.6 - Lever plan browser discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 Local-first, review-first automation for job applications. This repo now ships the end-to-end dry-run demo experience: a Typer CLI that boots a FastAPI preview service, serves a React UI, and lets you approve/decline edits before anything is submitted.
 
-Status: Story 3.3 (Profile-driven filling & validation) implemented.
+Status: Story 4.1.6 (Lever plan Browser discovery) implemented.
+
+## What’s New in 4.1.6
+- `python app.py apply plan --source lever-google` can launch Browser-Use with `--browser-discovery` to capture SERP HTML,
+  persist artifacts under `runs/<id>/plan/`, and enrich plan JSON with deduped Lever results.
+- Programmable Search support: use `--programmable-search` together with `GOOGLE_CSE_KEY`/`GOOGLE_CSE_CX` (or CLI overrides)
+  to call Google’s Custom Search API when headless discovery is preferred.
+- Plan guardrails now record Google allowlist domains alongside Lever defaults so run summaries reflect the expanded surface.
 
 ## What’s New in 3.3
 - `python app.py apply open` now replays the persisted SimplyHired `FormFillPlan` instead of re-scraping HTML. The new
@@ -123,8 +130,11 @@ Create `.env.local` at repo root (optional):
 ```env
 OPENROUTER_API_KEY=...
 OPENROUTER_MODEL=deepseek/deepseek-chat-v3.1:free
+GOOGLE_CSE_KEY=...        # optional: Google Programmable Search API key
+GOOGLE_CSE_CX=...         # optional: Programmable Search engine id
 ```
-The app logs a JSON warning if `.env.local` is missing and continues.
+The app logs a JSON warning if `.env.local` is missing and continues. When Programmable Search credentials are present the CLI
+can use `--programmable-search` to call Google’s Custom Search API without launching Browser-Use.
 
 ### Profiles
 ```bash
@@ -164,6 +174,16 @@ python app.py apply open "https://www.simplyhired.com/search?q=python" \
 The command resolves the Chrome `user_data_dir` to `.local/browser/profiles/<profile>`, honors overrides from `config/config.yaml` or `data/profiles/<id>.yaml`, and returns a JSON payload with the session identifier plus a `profile` object describing the active binding (resume path, QA overrides, guardrails). If the selected profile fails validation or the resume PDF is missing, the CLI exits with `profiles.validation_failed` before launching Chrome. Dry-run mode continues to fall back to the `demo` profile only when no active profile is configured.
 
 After the search readiness check succeeds the CLI now snapshots the resolved session directory to `.local/browser/backups/<profile>/` and records the result under the `backups` key in the JSON response. Restores run automatically when Chrome launch detects a corrupted profile (e.g., missing `Preferences`), retrying exactly once before surfacing an error. Operators can opt out per run with `--session-backups/--no-session-backups` or by setting `browser_session_backups.enabled` in the global/profile config files. Run metadata (`runs/<id>/run.json`) keeps the same `sessionBackup` structure so history tooling can inspect the latest snapshot and any restore attempts.
+
+### Lever Plan Discovery Modes
+- `python app.py apply plan --browser-discovery` launches Browser-Use for each SERP URL in the generated plan, saves the raw HTML
+  under `runs/<id>/plan/serp-page-*.html`, and populates the emitted JSON with unique Lever results. Guardrails expand to include
+  `www.google.com`, `*.google.com`, and `consent.google.com` alongside the existing Lever allowlist.
+- `--programmable-search` prefers Google’s Programmable Search JSON API when `GOOGLE_CSE_KEY`/`GOOGLE_CSE_CX` (or the CLI
+  overrides `--google-cse-key/--google-cse-cx`) are provided. This mode avoids launching Chrome and still emits the enriched
+  `results` array.
+- If both toggles are supplied, Programmable Search takes precedence; omitting both preserves the original headless HTTP fetch
+  behaviour from Story 4.0.
 
 #### Stealth Guardrails & Pacing
 - **Domain allowlist** – navigation is limited to the configured domains (`browser.allowed_domains`). Profile YAML can append additional domains per-identity.

--- a/apps/cli/config_loader.py
+++ b/apps/cli/config_loader.py
@@ -41,6 +41,12 @@ DEFAULTS = {
     "search_ready_selector_override": None,
     "search_ready_min_cards": 10,
     "quick_apply_selector_override": None,
+    "plan": {
+        "browser_discovery": False,
+        "programmable_search": False,
+        "google_cse_key": None,
+        "google_cse_cx": None,
+    },
 }
 
 
@@ -156,6 +162,10 @@ def load_env(base: Path | None = None) -> Dict[str, Any]:
         "OPENROUTER_API_KEY": os.environ.get("OPENROUTER_API_KEY"),
         "OPENROUTER_MODEL": os.environ.get("OPENROUTER_MODEL"),
     }
+    if google_cse_key := os.environ.get("GOOGLE_CSE_KEY"):
+        env_config["plan.google_cse_key"] = google_cse_key
+    if google_cse_cx := os.environ.get("GOOGLE_CSE_CX"):
+        env_config["plan.google_cse_cx"] = google_cse_cx
     # Allow optional environment overrides for demo helpers
     if chrome_path := os.environ.get("JAA_CHROME_PATH"):
         env_config["chrome_path"] = chrome_path
@@ -246,6 +256,10 @@ class Settings:
     search_ready_selector_override: str | None = DEFAULTS["search_ready_selector_override"]
     search_ready_min_cards: int = DEFAULTS["search_ready_min_cards"]
     quick_apply_selector_override: str | None = DEFAULTS["quick_apply_selector_override"]
+    plan_browser_discovery: bool = False
+    plan_programmable_search: bool = False
+    plan_google_cse_key: str | None = None
+    plan_google_cse_cx: str | None = None
     # Derived/env
     OPENROUTER_API_KEY: str | None = None
     OPENROUTER_MODEL: str | None = None
@@ -292,6 +306,34 @@ class Settings:
         data.update({k: v for k, v in env.items() if v is not None})
         if marker_profile := load_active_profile(base):
             data["active_profile"] = marker_profile
+        plan_dict = data.pop("plan", {}) or {}
+
+        def _assign_plan_option(target: Dict[str, Any], key: str, value: Any) -> None:
+            if value is None:
+                return
+            if key == "browser_discovery":
+                target["plan_browser_discovery"] = _to_bool(value)
+            elif key == "programmable_search":
+                target["plan_programmable_search"] = _to_bool(value)
+            elif key == "google_cse_key":
+                target["plan_google_cse_key"] = str(value)
+            elif key == "google_cse_cx":
+                target["plan_google_cse_cx"] = str(value)
+
+        if isinstance(plan_dict, dict):
+            for key, value in plan_dict.items():
+                _assign_plan_option(data, str(key), value)
+        for dotted_key in [key for key in list(data.keys()) if key.startswith("plan.")]:
+            _, subkey = dotted_key.split(".", 1)
+            _assign_plan_option(data, subkey, data.pop(dotted_key))
+        if "plan_browser_discovery" in data:
+            _assign_plan_option(data, "browser_discovery", data.pop("plan_browser_discovery"))
+        if "plan_programmable_search" in data:
+            _assign_plan_option(data, "programmable_search", data.pop("plan_programmable_search"))
+        if "plan_google_cse_key" in data:
+            _assign_plan_option(data, "google_cse_key", data.pop("plan_google_cse_key"))
+        if "plan_google_cse_cx" in data:
+            _assign_plan_option(data, "google_cse_cx", data.pop("plan_google_cse_cx"))
         # Allow nested browser config in YAML/env overrides (browser.* keys)
         browser_dict = data.pop("browser", {}) or {}
         if isinstance(browser_dict, dict):
@@ -404,6 +446,16 @@ class Settings:
                         processed["browser_session_backups_enabled"] = _to_bool(value)
                     elif subkey == "retention":
                         processed["browser_session_backups_retention"] = int(value)
+                elif key.startswith("plan."):
+                    _, subkey = key.split(".", 1)
+                    if subkey == "browser_discovery":
+                        processed["plan_browser_discovery"] = _to_bool(value)
+                    elif subkey == "programmable_search":
+                        processed["plan_programmable_search"] = _to_bool(value)
+                    elif subkey == "google_cse_key":
+                        processed["plan_google_cse_key"] = value
+                    elif subkey == "google_cse_cx":
+                        processed["plan_google_cse_cx"] = value
                 else:
                     processed[key] = value
             data.update(processed)
@@ -463,6 +515,22 @@ class Settings:
                 )
             ),
         )
+        data["plan_browser_discovery"] = _to_bool(
+            data.get("plan_browser_discovery", False)
+        )
+        data["plan_programmable_search"] = _to_bool(
+            data.get("plan_programmable_search", False)
+        )
+        if data.get("plan_google_cse_key"):
+            key_value = str(data["plan_google_cse_key"]).strip()
+            data["plan_google_cse_key"] = key_value or None
+        else:
+            data["plan_google_cse_key"] = None
+        if data.get("plan_google_cse_cx"):
+            cx_value = str(data["plan_google_cse_cx"]).strip()
+            data["plan_google_cse_cx"] = cx_value or None
+        else:
+            data["plan_google_cse_cx"] = None
         return cls(**data)
 
     def to_json(self) -> str:

--- a/apps/cli/main.py
+++ b/apps/cli/main.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Optional
 from urllib.error import URLError
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 from urllib.request import Request, urlopen
 
 import typer
@@ -187,6 +188,9 @@ def _lever_guardrail_domains() -> list[str]:
     ]
 
 
+PLAN_GOOGLE_DOMAINS = ["www.google.com", "*.google.com", "consent.google.com"]
+
+
 def _iso_now() -> str:
     """Return the current UTC timestamp in ISO-8601 format."""
 
@@ -268,6 +272,303 @@ def _plan_candidates(
     return results
 
 
+def _normalize_lever_href(url: str) -> tuple[str, str] | None:
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        parsed = parsed._replace(scheme="https")
+    host = parsed.netloc.lower()
+    if not host:
+        return None
+    if not host.endswith("jobs.lever.co"):
+        return None
+    cleaned = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+    normalized_path = parsed.path.rstrip("/")
+    is_apply = normalized_path.endswith("/apply") or "/apply/" in normalized_path
+    mode = "apply_direct" if is_apply else "job_page"
+    return cleaned, mode
+
+
+def _fetch_cse_json(url: str) -> Mapping[str, Any] | None:
+    try:
+        request = Request(url)
+        with urlopen(request, timeout=20) as response:
+            charset = response.headers.get_content_charset() or "utf-8"
+            payload = response.read().decode(charset, errors="replace")
+            return json.loads(payload)
+    except URLError as error:
+        log_event(
+            {
+                "level": "warning",
+                "event": "lever.plan.cse_failed",
+                "message": "Programmable Search request failed.",
+                "url": url,
+                "error": getattr(error, "reason", str(error)),
+            }
+        )
+        return None
+
+
+def _discover_candidates_with_cse(
+    *,
+    plan_payload: Mapping[str, Any],
+    api_key: str,
+    cx: str,
+    time_window: str,
+    pages: int,
+    fetch_json: Callable[[str], Mapping[str, Any] | None] | None = None,
+) -> tuple[list[LeverSerpResult], dict[str, Any]]:
+    fetcher = fetch_json or _fetch_cse_json
+    plan_map = plan_payload.get("plan") if isinstance(plan_payload.get("plan"), Mapping) else {}
+    base_url = ""
+    if isinstance(plan_map, Mapping):
+        base_value = plan_map.get("baseUrl")
+        if isinstance(base_value, str):
+            base_url = base_value
+    if not base_url:
+        search_map = plan_payload.get("search") if isinstance(plan_payload.get("search"), Mapping) else {}
+        terms = search_map.get("terms") if isinstance(search_map, Mapping) else []
+        location = search_map.get("location") if isinstance(search_map, Mapping) else None
+        terms_list = [str(term) for term in terms] if isinstance(terms, (list, tuple)) else []
+        discovery_plan = LeverGoogleDiscovery.plan(terms_list, location, time_window=time_window, pages=1)
+        base_url = discovery_plan.base_url
+    parsed = urlparse(base_url)
+    query_params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    q_param = query_params.get("q", "")
+    tbs = query_params.get("tbs", "")
+    time_map = {
+        "qdr:h": "d1",
+        "qdr:d": "d1",
+        "qdr:w": "w1",
+        "qdr:m": "m1",
+        "qdr:y": "y1",
+    }
+    window_map = {"h": "d1", "d": "d1", "w": "w1", "m": "m1", "y": "y1"}
+    date_restrict = time_map.get(tbs) or window_map.get(time_window)
+    results: list[LeverSerpResult] = []
+    seen: set[str] = set()
+    api_calls = 0
+    max_pages = max(1, pages)
+    for index in range(max_pages):
+        params = {
+            "key": api_key,
+            "cx": cx,
+            "q": q_param,
+            "num": 10,
+            "start": index * 10 + 1,
+        }
+        if date_restrict:
+            params["dateRestrict"] = date_restrict
+        request_url = f"https://www.googleapis.com/customsearch/v1?{urlencode(params)}"
+        log_event(
+            {
+                "event": "lever.plan.cse_request",
+                "page": index + 1,
+                "url": request_url,
+            }
+        )
+        payload = fetcher(request_url)
+        if not payload:
+            continue
+        api_calls += 1
+        items = payload.get("items") if isinstance(payload, Mapping) else None
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            link = str(item.get("link") or "").strip()
+            if not link:
+                continue
+            normalized = _normalize_lever_href(link)
+            if not normalized:
+                continue
+            href, mode = normalized
+            if href in seen:
+                continue
+            seen.add(href)
+            title = str(item.get("title") or href)
+            results.append(LeverSerpResult(title=title, href=href, mode=mode))
+        if len(items) < 10:
+            break
+    log_event(
+        {
+            "event": "lever.plan.cse_completed",
+            "results": len(results),
+            "apiCalls": api_calls,
+        }
+    )
+    return results, {"mode": "programmable_search", "apiCalls": api_calls}
+
+
+def _discover_candidates_with_browser(
+    *,
+    plan_payload: Mapping[str, Any],
+    settings: Settings,
+    profile_id: str,
+    binding: ProfileBinding | None,
+    base: Path,
+) -> tuple[list[LeverSerpResult], dict[str, Any]]:
+    binding = binding or ProfileBinding.demo(base, profile_id=profile_id)
+    binding.user_data_dir.mkdir(parents=True, exist_ok=True)
+    guardrail_domains: list[str]
+    overrides_domains = binding.browser_overrides.get("allowed_domains") if binding.browser_overrides else None
+    if isinstance(overrides_domains, (list, tuple)) and overrides_domains:
+        guardrail_domains = [str(domain).strip() for domain in overrides_domains if str(domain).strip()]
+    else:
+        guardrail_domains = [str(domain).strip() for domain in settings.browser_allowed_domains]
+    for domain in _lever_guardrail_domains():
+        if domain not in guardrail_domains:
+            guardrail_domains.append(domain)
+    for domain in PLAN_GOOGLE_DOMAINS:
+        if domain not in guardrail_domains:
+            guardrail_domains.append(domain)
+    wait_range = tuple(int(value) for value in settings.browser_pacing_wait_jitter_ms)
+    think_range = tuple(float(value) for value in settings.browser_pacing_think_time_range_s)
+    browser_model_override = (
+        binding.browser_overrides.get("model") if binding.browser_overrides else None
+    )
+    profile_model = binding.model_overrides.get("llm") if binding.model_overrides else None
+    effective_model = (
+        browser_model_override
+        or profile_model
+        or settings.OPENROUTER_MODEL
+        or settings.browser_model
+    )
+    if not effective_model:
+        raise ApiError(
+            code="plan.browser.model_missing",
+            message="No Browser-Use model configured for plan discovery.",
+            details={"profileId": profile_id},
+        )
+    search_map = plan_payload.get("search") if isinstance(plan_payload.get("search"), Mapping) else {}
+    source = "lever-google"
+    if isinstance(search_map, Mapping) and isinstance(search_map.get("source"), str):
+        source = str(search_map.get("source"))
+    launch_config = BrowserLaunchConfig(
+        profile_id=profile_id,
+        user_data_dir=binding.user_data_dir,
+        model=effective_model,
+        viewport_width=settings.browser_viewport_width,
+        viewport_height=settings.browser_viewport_height,
+        locale=settings.browser_locale,
+        timezone=settings.browser_timezone,
+        chrome_path=settings.chrome_path,
+        guardrail_domains=tuple(guardrail_domains),
+        wait_jitter_ms=wait_range,
+        think_time_range_s=think_range,
+        profile_metadata={"mode": "plan", "source": source},
+        profile_binding=binding.telemetry_payload(),
+    )
+    run_store = RunStore(base=base)
+    run_record = run_store.start_lever_plan_discovery(
+        profile_id=profile_id,
+        source=source,
+        plan_payload=plan_payload,
+        guardrails=guardrail_domains,
+        discovery_mode="browser",
+        profile_binding=binding.cli_payload(),
+    )
+    plan_dir = run_record.run_dir / "plan"
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    plan_map = plan_payload.get("plan") if isinstance(plan_payload.get("plan"), Mapping) else {}
+    urls: list[str] = []
+    if isinstance(plan_map, Mapping):
+        raw_urls = plan_map.get("urls")
+        if isinstance(raw_urls, (list, tuple)):
+            urls = [str(item) for item in raw_urls if str(item).strip()]
+    log_event(
+        {
+            "event": "lever.plan.browser.start",
+            "runId": run_record.id,
+            "urls": len(urls),
+            "guardrails": guardrail_domains,
+        }
+    )
+    controller = BrowserUseController(launch_config)
+    artifacts: list[dict[str, Any]] = []
+    results: list[LeverSerpResult] = []
+    seen: set[str] = set()
+    try:
+        for index, url in enumerate(urls, start=1):
+            artifact_path = plan_dir / f"serp-page-{index:02}.html"
+            log_event(
+                {
+                    "event": "lever.plan.browser.navigate",
+                    "page": index,
+                    "url": url,
+                    "runId": run_record.id,
+                }
+            )
+            navigation = controller.open_url(url)
+            if navigation.status != BrowserActionStatus.OK:
+                log_event(
+                    {
+                        "level": "warning",
+                        "event": "lever.plan.browser.navigation_failed",
+                        "page": index,
+                        "url": url,
+                        "details": navigation.details,
+                        "runId": run_record.id,
+                    }
+                )
+                continue
+            controller.wait_for_idle(timeout=12.0)
+            page_html = controller.get_page_html()
+            html = ""
+            if isinstance(page_html.details, Mapping):
+                html = str(page_html.details.get("html") or "")
+            if not html.strip():
+                log_event(
+                    {
+                        "level": "warning",
+                        "event": "lever.plan.browser.empty_html",
+                        "page": index,
+                        "url": url,
+                        "runId": run_record.id,
+                    }
+                )
+                continue
+            artifact_path.write_text(html, encoding="utf-8")
+            artifacts.append({"path": str(artifact_path), "url": url})
+            for result in LeverGoogleDiscovery.extract_results(html):
+                if result.href in seen:
+                    continue
+                seen.add(result.href)
+                results.append(result)
+    finally:
+        try:
+            controller.close()
+        except Exception:
+            pass
+        run_store.record_plan_discovery(
+            run_record,
+            {
+                "guardrails": guardrail_domains,
+                "artifacts": artifacts,
+                "results": [
+                    {"title": r.title, "href": r.href, "mode": r.mode} for r in results
+                ],
+                "mode": "browser",
+                "summary": {"pages": len(artifacts), "results": len(results)},
+            },
+        )
+        log_event(
+            {
+                "event": "lever.plan.browser.completed",
+                "runId": run_record.id,
+                "pages": len(artifacts),
+                "results": len(results),
+            }
+        )
+        set_run_context(None)
+    return results, {
+        "guardrails": guardrail_domains,
+        "artifacts": artifacts,
+        "run_id": run_record.id,
+        "run_dir": str(run_record.run_dir),
+        "mode": "browser",
+        "summary": {"pages": len(artifacts), "results": len(results)},
+    }
 def _queue_upsert(snapshot: dict[str, Any], entry: Mapping[str, Any]) -> None:
     """Insert or update a pending queue entry in-place."""
 
@@ -352,10 +653,41 @@ def apply_plan(
     ),
     pages: int = typer.Option(1, "--pages", min=1, help="Number of SERP pages (10 results each)."),
     profile: Optional[str] = typer.Option(None, "--profile", help="Profile identifier to bind."),
+    browser_discovery: Optional[bool] = typer.Option(
+        None,
+        "--browser-discovery/--no-browser-discovery",
+        help="Use Browser-Use to capture SERP HTML and dedupe Lever results.",
+    ),
+    programmable_search: Optional[bool] = typer.Option(
+        None,
+        "--programmable-search/--no-programmable-search",
+        help="Use Google Programmable Search when credentials are configured.",
+    ),
+    google_cse_key: Optional[str] = typer.Option(
+        None,
+        "--google-cse-key",
+        help="Override Google Custom Search API key for this invocation.",
+    ),
+    google_cse_cx: Optional[str] = typer.Option(
+        None,
+        "--google-cse-cx",
+        help="Override Google Programmable Search engine identifier.",
+    ),
 ):
     """Plan discovery URLs for supported sources (lever-google review flow)."""
 
-    settings = Settings.load(overrides={"active_profile": profile} if profile else None)
+    overrides: dict[str, Any] = {}
+    if profile:
+        overrides["active_profile"] = profile
+    if browser_discovery is not None:
+        overrides["plan.browser_discovery"] = browser_discovery
+    if programmable_search is not None:
+        overrides["plan.programmable_search"] = programmable_search
+    if google_cse_key:
+        overrides["plan.google_cse_key"] = google_cse_key
+    if google_cse_cx:
+        overrides["plan.google_cse_cx"] = google_cse_cx
+    settings = Settings.load(overrides=overrides or None)
     base = get_base_dir()
     service = ProfileService(base=base)
 
@@ -398,6 +730,119 @@ def apply_plan(
         time_window=qdr,
         pages=pages,
     )
+
+    plan_preferences = {
+        "browser_discovery": bool(settings.plan_browser_discovery),
+        "programmable_search": bool(settings.plan_programmable_search),
+        "google_cse_key": settings.plan_google_cse_key,
+        "google_cse_cx": settings.plan_google_cse_cx,
+    }
+    profile_plan_overrides: Mapping[str, Any] = {}
+    if profile_config is not None:
+        profile_plan_overrides = profile_config.resolved_plan_overrides()
+    elif binding is not None and binding.plan_overrides:
+        profile_plan_overrides = binding.plan_overrides
+    if browser_discovery is None and profile_plan_overrides.get("browser_discovery") is not None:
+        plan_preferences["browser_discovery"] = bool(
+            profile_plan_overrides["browser_discovery"]
+        )
+    if programmable_search is None and profile_plan_overrides.get("programmable_search") is not None:
+        plan_preferences["programmable_search"] = bool(
+            profile_plan_overrides["programmable_search"]
+        )
+    if google_cse_key is None and not plan_preferences["google_cse_key"]:
+        if profile_plan_overrides.get("google_cse_key"):
+            plan_preferences["google_cse_key"] = profile_plan_overrides["google_cse_key"]
+    if google_cse_cx is None and not plan_preferences["google_cse_cx"]:
+        if profile_plan_overrides.get("google_cse_cx"):
+            plan_preferences["google_cse_cx"] = profile_plan_overrides["google_cse_cx"]
+
+    use_cse = (
+        plan_preferences["programmable_search"]
+        and bool(plan_preferences["google_cse_key"])
+        and bool(plan_preferences["google_cse_cx"])
+    )
+    if plan_preferences["programmable_search"] and not use_cse:
+        log_event(
+            {
+                "level": "warning",
+                "event": "lever.plan.cse_credentials_missing",
+                "message": "Programmable Search requested but GOOGLE_CSE_KEY/CX are missing; falling back to other discovery mode.",
+            }
+        )
+    use_browser = bool(plan_preferences["browser_discovery"])
+    results: list[LeverSerpResult] = []
+    discovery_metadata: dict[str, Any] = {}
+    discovery_mode = "http"
+    if use_cse:
+        results, discovery_metadata = _discover_candidates_with_cse(
+            plan_payload=payload,
+            api_key=str(plan_preferences["google_cse_key"]),
+            cx=str(plan_preferences["google_cse_cx"]),
+            time_window=qdr,
+            pages=pages,
+        )
+        discovery_mode = "programmable_search"
+    elif use_browser:
+        try:
+            results, discovery_metadata = _discover_candidates_with_browser(
+                plan_payload=payload,
+                settings=settings,
+                profile_id=profile_id,
+                binding=binding,
+                base=base,
+            )
+        except ApiError as error:
+            typer.secho(error.to_json(), fg=typer.colors.RED)
+            raise typer.Exit(code=1)
+        except (BrowserUseError, BrowserLaunchError) as error:
+            typer.secho(str(error), fg=typer.colors.RED)
+            raise typer.Exit(code=1)
+        discovery_mode = "browser"
+
+    if discovery_metadata.get("guardrails"):
+        payload.setdefault("guardrails", {})["allowed_domains"] = list(
+            discovery_metadata["guardrails"]
+        )
+    plan_section = payload.setdefault("plan", {})
+    if discovery_metadata.get("artifacts"):
+        plan_section["artifacts"] = list(discovery_metadata["artifacts"])
+    if discovery_metadata.get("summary"):
+        summary = plan_section.get("summary", {}) if isinstance(plan_section.get("summary"), Mapping) else {}
+        summary.update(discovery_metadata["summary"])
+        plan_section["summary"] = summary
+    if discovery_metadata.get("mode"):
+        plan_section["discoveryMode"] = discovery_metadata["mode"]
+    if discovery_metadata.get("run_id"):
+        plan_section["runId"] = discovery_metadata["run_id"]
+    if discovery_metadata.get("run_dir"):
+        plan_section["runDir"] = discovery_metadata["run_dir"]
+    if discovery_metadata.get("apiCalls"):
+        summary = plan_section.get("summary", {}) if isinstance(plan_section.get("summary"), Mapping) else {}
+        summary.setdefault("apiCalls", discovery_metadata["apiCalls"])
+        plan_section["summary"] = summary
+    if results:
+        payload["results"] = [
+            {"title": item.title, "href": item.href, "mode": item.mode}
+            for item in results
+        ]
+
+    if discovery_mode == "browser" and discovery_metadata.get("run_dir"):
+        run_dir_path = Path(discovery_metadata["run_dir"])
+        plan_output_path = run_dir_path / "plan" / "plan.json"
+        plan_output_path.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+
+    if discovery_mode != "http":
+        log_event(
+            {
+                "event": "lever.plan.discovery_completed",
+                "mode": discovery_mode,
+                "results": len(results),
+            }
+        )
+
     typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
 
 

--- a/apps/cli/profiles.py
+++ b/apps/cli/profiles.py
@@ -83,6 +83,7 @@ class ProfileBinding:
     qa_overrides: Dict[str, str]
     model_overrides: Dict[str, Any]
     browser_overrides: Dict[str, Any]
+    plan_overrides: Dict[str, Any]
     session_backups_enabled: bool | None
     session_backups_retention: int | None
     resume_exists: bool
@@ -109,6 +110,7 @@ class ProfileBinding:
             "qa_overrides": dict(self.qa_overrides),
             "model_overrides": dict(self.model_overrides),
             "browser": dict(self.browser_overrides),
+            "plan": dict(self.plan_overrides),
             "session_backups": {
                 "enabled": self.session_backups_enabled,
                 "retention": self.session_backups_retention,
@@ -129,6 +131,7 @@ class ProfileBinding:
             "qaOverrideKeys": sorted(self.qa_overrides.keys()),
             "model": self.model_overrides.get("llm"),
             "browser": dict(self.browser_overrides),
+            "plan": dict(self.plan_overrides),
             "sessionBackups": {
                 "enabled": self.session_backups_enabled,
                 "retention": self.session_backups_retention,
@@ -162,6 +165,7 @@ class ProfileBinding:
             qa_overrides=dict(profile.qa_overrides),
             model_overrides=dict(profile.model_overrides),
             browser_overrides=profile.resolved_browser_overrides(),
+            plan_overrides=profile.resolved_plan_overrides(),
             session_backups_enabled=profile.session_backups.enabled
             if profile.session_backups
             else None,
@@ -186,6 +190,7 @@ class ProfileBinding:
             qa_overrides={},
             model_overrides={},
             browser_overrides={},
+            plan_overrides={},
             session_backups_enabled=None,
             session_backups_retention=None,
             resume_exists=resume_path.exists(),
@@ -352,6 +357,31 @@ class ProfileConfig(BaseModel):
             return value
 
     search: SearchConfig | None = Field(default=None, alias="search")
+    class PlanOverridesConfig(BaseModel):
+        browser_discovery: bool | None = Field(
+            default=None,
+            alias="browser_discovery",
+            description="Enable Browser-Use discovery for planning",
+        )
+        programmable_search: bool | None = Field(
+            default=None,
+            alias="programmable_search",
+            description="Prefer Google Programmable Search when credentials present",
+        )
+        google_cse_key: str | None = Field(
+            default=None,
+            alias="google_cse_key",
+            description="API key for Google Custom Search",
+        )
+        google_cse_cx: str | None = Field(
+            default=None,
+            alias="google_cse_cx",
+            description="Programmable Search engine identifier",
+        )
+
+        model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    plan: PlanOverridesConfig | None = Field(default=None, alias="plan")
     browser: BrowserOverridesConfig | None = Field(
         default=None,
         alias="browser",
@@ -447,6 +477,22 @@ class ProfileConfig(BaseModel):
                 overrides["pacing"] = pacing
         return overrides
 
+    def resolved_plan_overrides(self) -> Dict[str, Any]:
+        """Return plan discovery overrides for CLI/config merging."""
+
+        if not self.plan:
+            return {}
+        overrides: Dict[str, Any] = {}
+        if self.plan.browser_discovery is not None:
+            overrides["browser_discovery"] = bool(self.plan.browser_discovery)
+        if self.plan.programmable_search is not None:
+            overrides["programmable_search"] = bool(self.plan.programmable_search)
+        if self.plan.google_cse_key:
+            overrides["google_cse_key"] = self.plan.google_cse_key.strip()
+        if self.plan.google_cse_cx:
+            overrides["google_cse_cx"] = self.plan.google_cse_cx.strip()
+        return overrides
+
 
 @dataclass
 class ProfileValidationResult:
@@ -507,6 +553,11 @@ PROFILE_TEMPLATE = (
     "  terms: ['front end']\n"
     "  location: 'remote us'\n"
     "  time_window: d\n"
+    "plan:\n"
+    "  browser_discovery: false\n"
+    "  programmable_search: false\n"
+    "  google_cse_key: null\n"
+    "  google_cse_cx: null\n"
 )
 
 

--- a/apps/cli/run_store.py
+++ b/apps/cli/run_store.py
@@ -9,7 +9,7 @@ import secrets
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional, Sequence
 
 from apps.preview.constants import (
     PLACEHOLDER_NOTES,
@@ -293,6 +293,93 @@ class RunStore:
         )
         return record
 
+    def start_lever_plan_discovery(
+        self,
+        *,
+        profile_id: Optional[str],
+        source: str,
+        plan_payload: Mapping[str, Any],
+        guardrails: Sequence[str],
+        discovery_mode: str,
+        profile_binding: Optional[Dict[str, Any]] = None,
+    ) -> RunRecord:
+        """Create a run directory for Lever plan discovery flows."""
+
+        timestamp = datetime.now(timezone.utc)
+        slug = secrets.token_hex(4)
+        run_id = f"{timestamp:%Y%m%d-%H%M%S}-{slug}"
+        run_dir = self.runs_dir / run_id
+        run_dir.mkdir(parents=True, exist_ok=False)
+        plan_dir = run_dir / "plan"
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        logs_path = run_dir / "actions.log"
+        logs_path.touch(exist_ok=True)
+        record = RunRecord(
+            id=run_id,
+            started_at=timestamp,
+            run_dir=run_dir,
+            run_json_path=run_dir / "run.json",
+            logs_path=logs_path,
+            profile_id=profile_id,
+            screenshot_path=None,
+        )
+        plan_map = plan_payload.get("plan") if isinstance(plan_payload.get("plan"), Mapping) else {}
+        plan_urls: Sequence[str] = []
+        plan_pages = None
+        if isinstance(plan_map, Mapping):
+            urls_value = plan_map.get("urls")
+            if isinstance(urls_value, Sequence):
+                plan_urls = [str(url) for url in urls_value]
+            pages_value = plan_map.get("pages")
+            if isinstance(pages_value, (int, float)):
+                plan_pages = int(pages_value)
+        metadata: Dict[str, Any] = {
+            "mode": "plan",
+            "profileLabel": format_profile_label(profile_id),
+            "source": source,
+            "discoveryMode": discovery_mode,
+        }
+        if profile_binding is not None:
+            metadata["profileBinding"] = profile_binding
+        plan_section: Dict[str, Any] = {
+            "source": source,
+            "search": plan_payload.get("search"),
+            "guardrails": list(guardrails),
+            "mode": discovery_mode,
+            "urls": list(plan_urls),
+            "artifacts": [],
+            "results": [],
+        }
+        if plan_pages is not None:
+            plan_section["pages"] = plan_pages
+        if plan_payload.get("notes"):
+            plan_section["notes"] = list(plan_payload.get("notes", []))
+        if plan_payload.get("profile"):
+            plan_section["profile"] = plan_payload.get("profile")
+        payload: Dict[str, Any] = {
+            "id": record.id,
+            "startedAt": record.started_at.isoformat().replace("+00:00", "Z"),
+            "status": "plan_pending",
+            "profileId": profile_id,
+            "artifactsDir": str(run_dir),
+            "logsPath": str(logs_path),
+            "metadata": metadata,
+            "plan": plan_section,
+        }
+        self._write_run_json(record.run_json_path, payload)
+        set_run_context(
+            RunContext(
+                id=record.id,
+                started_at=record.started_at,
+                run_dir=record.run_dir,
+                run_json_path=record.run_json_path,
+                logs_path=record.logs_path,
+                profile_id=record.profile_id,
+                profile_binding=profile_binding,
+            )
+        )
+        return record
+
     # region Demo mutation helpers
 
     def bootstrap_demo_preview(
@@ -406,6 +493,31 @@ class RunStore:
         data["status"] = "quick_apply_discovery"
         self._write_run_json(record.run_json_path, data)
         return data
+
+    def record_plan_discovery(
+        self, record: RunRecord, discovery_payload: Mapping[str, Any]
+    ) -> Dict[str, Any]:
+        """Persist plan discovery metadata and results for the given run."""
+
+        data = self._load_run_json(record.run_json_path)
+        plan_section = data.setdefault("plan", {})
+        if discovery_payload.get("guardrails") is not None:
+            plan_section["guardrails"] = list(discovery_payload.get("guardrails", []))
+        if discovery_payload.get("artifacts") is not None:
+            plan_section["artifacts"] = list(discovery_payload.get("artifacts", []))
+        if discovery_payload.get("results") is not None:
+            plan_section["results"] = list(discovery_payload.get("results", []))
+        if discovery_payload.get("mode"):
+            plan_section["mode"] = discovery_payload["mode"]
+        if discovery_payload.get("summary"):
+            plan_section["summary"] = discovery_payload["summary"]
+        data["plan"] = plan_section
+        if discovery_payload.get("metadata"):
+            metadata = data.setdefault("metadata", {})
+            metadata.update(discovery_payload["metadata"])
+        data["status"] = discovery_payload.get("status", "plan_completed")
+        self._write_run_json(record.run_json_path, data)
+        return plan_section
 
     def record_form_plan(
         self, record: RunRecord, form_plan_payload: Dict[str, Any]

--- a/apps/cli/tests/test_apply_plan.py
+++ b/apps/cli/tests/test_apply_plan.py
@@ -1,0 +1,354 @@
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+try:
+    import typer  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency guard
+    class _TyperExit(Exception):
+        def __init__(self, code: int | None = None) -> None:
+            super().__init__(code)
+            self.code = code
+
+    def _identity_decorator(*_args, **_kwargs):
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    def _option_stub(*_args, **_kwargs):
+        return _kwargs.get("default")
+
+    def _echo_stub(message: str, **_kwargs) -> None:
+        print(message)
+
+    typer = types.SimpleNamespace(  # type: ignore[assignment]
+        Typer=lambda *args, **kwargs: types.SimpleNamespace(
+            command=_identity_decorator, callback=_identity_decorator
+        ),
+        Option=_option_stub,
+        Argument=_option_stub,
+        Exit=_TyperExit,
+        secho=_echo_stub,
+        echo=_echo_stub,
+        colors=types.SimpleNamespace(RED="red", GREEN="green", YELLOW="yellow"),
+    )
+    sys.modules["typer"] = typer  # type: ignore[assignment]
+
+try:
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency guard
+    sys.modules["yaml"] = types.SimpleNamespace(
+        safe_load=lambda *_args, **_kwargs: {},
+        safe_dump=lambda *_args, **_kwargs: "{}\n",
+    )
+
+try:
+    import dotenv  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency guard
+    sys.modules["dotenv"] = types.SimpleNamespace(load_dotenv=lambda *_args, **_kwargs: False)
+
+try:
+    import portalocker  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency guard
+    class _PortalockerLock:
+        def __init__(self, path, mode, *, flags=None):
+            self._path = path
+            self._mode = mode
+            self._handle = None
+
+        def __enter__(self):
+            self._handle = open(self._path, self._mode)
+            return self._handle
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            if self._handle:
+                self._handle.close()
+
+    sys.modules["portalocker"] = types.SimpleNamespace(
+        LockFlags=types.SimpleNamespace(EXCLUSIVE=1),
+        Lock=lambda path, mode, **kwargs: _PortalockerLock(path, mode, **kwargs),
+    )
+
+try:  # pragma: no cover - optional dependency guard
+    import bs4  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency guard
+    class _Tag:
+        pass
+
+    class _BeautifulSoup:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def select(self, *_args, **_kwargs):
+            return []
+
+        def find_all(self, *_args, **_kwargs):
+            return []
+
+    bs4_module = types.ModuleType("bs4")
+    bs4_module.BeautifulSoup = _BeautifulSoup
+    bs4_module.Tag = _Tag
+    sys.modules["bs4"] = bs4_module
+
+try:  # pragma: no cover - optional dependency guard
+    import fastapi  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency guard
+    class _FastAPIState(types.SimpleNamespace):
+        pass
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: object | None = None) -> None:
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class FastAPI:  # type: ignore[override]
+        def __init__(self, *args, **kwargs) -> None:
+            self.state = _FastAPIState()
+            self._routes: dict[tuple[str, str], callable] = {}
+
+        def mount(self, *_args, **_kwargs) -> None:
+            return None
+
+        def get(self, path: str, **_kwargs):
+            def decorator(func):
+                self._routes[("GET", path)] = func
+                return func
+
+            return decorator
+
+        def post(self, path: str, **_kwargs):
+            def decorator(func):
+                self._routes[("POST", path)] = func
+                return func
+
+            return decorator
+
+    class FileResponse:  # pragma: no cover - placeholder for FastAPI response
+        def __init__(self, path: Path | str, *args, **kwargs) -> None:
+            self.path = Path(path)
+
+    class StaticFiles:  # pragma: no cover - placeholder for FastAPI static handler
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+    fastapi_module = types.ModuleType("fastapi")
+    fastapi_module.FastAPI = FastAPI
+    fastapi_module.HTTPException = HTTPException
+    fastapi_responses = types.ModuleType("fastapi.responses")
+    fastapi_responses.FileResponse = FileResponse
+    fastapi_staticfiles = types.ModuleType("fastapi.staticfiles")
+    fastapi_staticfiles.StaticFiles = StaticFiles
+    fastapi_module.responses = fastapi_responses
+    fastapi_module.staticfiles = fastapi_staticfiles
+    sys.modules["fastapi"] = fastapi_module
+    sys.modules["fastapi.responses"] = fastapi_responses
+    sys.modules["fastapi.staticfiles"] = fastapi_staticfiles
+
+try:  # pragma: no cover - optional dependency guard
+    import pydantic  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency guard
+    class _BaseModel:
+        def __init__(self, **data) -> None:
+            for key, value in data.items():
+                setattr(self, key, value)
+
+        def model_dump(self) -> dict[str, object]:
+            return self.__dict__.copy()
+
+    def _field(default=None, **_kwargs):
+        return default
+
+    pydantic_module = types.ModuleType("pydantic")
+    pydantic_module.BaseModel = _BaseModel
+    pydantic_module.Field = _field
+    sys.modules["pydantic"] = pydantic_module
+
+sys.path.insert(0, os.getcwd())
+
+from apps.browser import BrowserActionResult, BrowserActionStatus
+from apps.cli.main import PLAN_GOOGLE_DOMAINS, apply_plan
+from sites.lever.lever_google_discovery import LeverSerpResult
+
+
+def _write_profile(tmp_path: Path, profile_id: str = "qa-tester") -> Path:
+    profile_dir = tmp_path / "data" / "profiles"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    resume_path = tmp_path / "data" / "resumes" / profile_id / "resume.pdf"
+    resume_path.parent.mkdir(parents=True, exist_ok=True)
+    resume_path.write_bytes(b"%PDF-1.4\n")
+    profile_yaml = f"""
+identity:
+  full_name: "Test User"
+  email: "user@example.com"
+  phone: null
+  location: "Remote"
+  portfolio: []
+documents:
+  resume_path: {resume_path.relative_to(tmp_path)}
+id: "{profile_id}"
+display_name: "QA Tester"
+model_overrides: {{}}
+qa_overrides: {{}}
+links: {{}}
+user_data_dir: .local/browser/profiles/{profile_id}
+search:
+  source: lever-google
+  terms: ['front end']
+  location: 'remote us'
+  time_window: d
+plan:
+  browser_discovery: false
+  programmable_search: false
+  google_cse_key: null
+  google_cse_cx: null
+"""
+    profile_path = profile_dir / f"{profile_id}.yaml"
+    profile_path.write_text(profile_yaml.strip() + "\n", encoding="utf-8")
+    return profile_path
+
+
+class _StubPlanController:
+    last_config = None
+    html_content = "<html><body><a href='https://jobs.lever.co/acme/role/apply'>Apply</a></body></html>"
+
+    def __init__(self, config) -> None:
+        _StubPlanController.last_config = config
+        self._html = _StubPlanController.html_content
+
+    def open_url(self, url: str) -> BrowserActionResult:
+        return BrowserActionResult(
+            status=BrowserActionStatus.OK,
+            details={"response": {"url": url}},
+            telemetry={"event": "stub.open"},
+        )
+
+    def wait_for_idle(self, timeout: float = 5.0) -> BrowserActionResult:
+        return BrowserActionResult(
+            status=BrowserActionStatus.OK,
+            details={"response": {"timeout": timeout}},
+            telemetry={"event": "stub.idle"},
+        )
+
+    def get_page_html(self) -> BrowserActionResult:
+        return BrowserActionResult(
+            status=BrowserActionStatus.OK,
+            details={"html": self._html},
+            telemetry={"event": "stub.html"},
+        )
+
+    def close(self) -> None:  # pragma: no cover - nothing to clean up
+        return None
+
+
+class _FailingController:
+    def __init__(self, *_args, **_kwargs) -> None:  # pragma: no cover - guard for precedence
+        raise AssertionError("Browser controller should not be constructed for CSE mode")
+
+
+def _read_plan_payload(capsys) -> dict[str, object]:
+    captured = capsys.readouterr().out
+    trimmed = captured.strip()
+    start = trimmed.rfind("\n{")
+    if start == -1:
+        start = 0
+    payload_str = trimmed[start:].strip()
+    return json.loads(payload_str)
+
+
+def test_apply_plan_with_browser_discovery(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setenv("JAA_BASE_DIR", str(tmp_path))
+    _write_profile(tmp_path)
+
+    monkeypatch.setattr("apps.cli.main.BrowserUseController", _StubPlanController)
+    monkeypatch.setattr(
+        "apps.cli.main.LeverGoogleDiscovery.extract_results",
+        lambda html: [
+            LeverSerpResult(title="Role", href="https://jobs.lever.co/acme/role/apply", mode="apply_direct"),
+            LeverSerpResult(title="Role Duplicate", href="https://jobs.lever.co/acme/role/apply", mode="apply_direct"),
+            LeverSerpResult(title="Job Page", href="https://jobs.lever.co/acme/job", mode="job_page"),
+        ],
+    )
+
+    apply_plan(
+        source=None,
+        terms=None,
+        location=None,
+        time_window=None,
+        pages=1,
+        profile="qa-tester",
+        browser_discovery=True,
+        programmable_search=None,
+        google_cse_key=None,
+        google_cse_cx=None,
+    )
+
+    payload = _read_plan_payload(capsys)
+    assert payload["plan"].get("discoveryMode") == "browser"
+    assert [result["href"] for result in payload["results"]] == [
+        "https://jobs.lever.co/acme/role/apply",
+        "https://jobs.lever.co/acme/job",
+    ]
+    guardrails = payload["guardrails"]["allowed_domains"]
+    for domain in PLAN_GOOGLE_DOMAINS:
+        assert domain in guardrails
+    run_dir = Path(payload["plan"]["runDir"])
+    artifact_path = run_dir / "plan" / "serp-page-01.html"
+    assert artifact_path.exists()
+    assert artifact_path.read_text(encoding="utf-8") == _StubPlanController.html_content
+
+
+def test_apply_plan_uses_programmable_search_when_credentials_present(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setenv("JAA_BASE_DIR", str(tmp_path))
+    _write_profile(tmp_path)
+
+    monkeypatch.setattr("apps.cli.main.BrowserUseController", _FailingController)
+
+    call_counter = {"count": 0}
+
+    def fake_fetch(url: str):
+        call_counter["count"] += 1
+        return {
+            "items": [
+                {
+                    "link": "https://jobs.lever.co/acme/engineering/apply",
+                    "title": "Engineer",
+                },
+                {
+                    "link": "https://jobs.lever.co/acme/support",
+                    "title": "Support",
+                },
+            ]
+        }
+
+    monkeypatch.setattr("apps.cli.main._fetch_cse_json", fake_fetch)
+
+    apply_plan(
+        source=None,
+        terms=None,
+        location=None,
+        time_window=None,
+        pages=1,
+        profile="qa-tester",
+        browser_discovery=True,
+        programmable_search=True,
+        google_cse_key="demo-key",
+        google_cse_cx="demo-cx",
+    )
+
+    payload = _read_plan_payload(capsys)
+    assert payload["plan"].get("discoveryMode") == "programmable_search"
+    assert payload["plan"].get("runDir") is None or payload["plan"].get("runDir") == ""
+    assert [result["href"] for result in payload["results"]] == [
+        "https://jobs.lever.co/acme/engineering/apply",
+        "https://jobs.lever.co/acme/support",
+    ]
+    assert payload["plan"].get("summary", {}).get("apiCalls") == call_counter["count"]
+    assert "allowed_domains" not in payload.get("guardrails", {}) or all(
+        domain not in PLAN_GOOGLE_DOMAINS for domain in payload.get("guardrails", {}).get("allowed_domains", [])
+    )

--- a/core/tests/test_profile_answer_resolver.py
+++ b/core/tests/test_profile_answer_resolver.py
@@ -50,6 +50,7 @@ def _build_binding() -> ProfileBinding:
         qa_overrides={"customQuestion": "N/A"},
         model_overrides={},
         browser_overrides={},
+        plan_overrides={},
         session_backups_enabled=None,
         session_backups_retention=None,
         resume_exists=True,

--- a/docs/prd/epic-4-review-gate-submission-integration.md
+++ b/docs/prd/epic-4-review-gate-submission-integration.md
@@ -57,6 +57,12 @@ Acceptance Criteria
 4. A toggle (`--browser-discovery/--no-browser-discovery`, default configurable via profile/global config) chooses between Browser-Use discovery and the existing HTTP fetch so CI and scripted flows remain headless by default.
 5. Automated tests mock the Browser-Use controller to cover both code paths, verifying JSON output, guardrail payloads, and artifact paths without launching real Chrome.
 
+**Implementation Notes**
+- CLI settings now accept `plan.browser_discovery`, `plan.programmable_search`, `plan.google_cse_key`, and `plan.google_cse_cx`; profile YAML mirrors these fields so operators can opt into discovery modes per identity.
+- `python app.py apply plan --browser-discovery` launches Browser-Use with expanded guardrails (`www.google.com`, `*.google.com`, `consent.google.com`) and writes SERP HTML to `runs/<id>/plan/serp-page-*.html`.
+- `--programmable-search` (with `GOOGLE_CSE_KEY`/`GOOGLE_CSE_CX` or CLI overrides) calls Google’s Programmable Search API and emits the same deduped `results` payload without starting Chrome; when both flags are set the API path takes precedence.
+- New unit tests (`apps/cli/tests/test_apply_plan.py`) cover Browser-Use and Programmable Search paths with mocked clients; README documents the new toggles and environment variables.
+
 ## Story 4.2 â€” Review Queue Persistence & APIs
 As an operator,
 I want the automation to queue multiple application candidates with deterministic state transitions,

--- a/docs/qa/gates/4.1.6-lever-plan-browser-discovery.yml
+++ b/docs/qa/gates/4.1.6-lever-plan-browser-discovery.yml
@@ -1,0 +1,42 @@
+schema: 1
+story: '4.1.6'
+story_title: 'Lever Plan Browser Discovery'
+gate: FAIL
+status_reason: 'pytest apps/cli/tests/test_apply_plan.py aborts on import because apps/cli/profiles.py requires pydantic.ConfigDict, which is unavailable in the current pydantic v1 runtime; Browser-Use and Programmable Search discovery paths remain unverified.'
+reviewer: 'QA (Test Architect)'
+updated: '2025-12-02T00:00:00Z'
+
+top_issues:
+  - id: QA-4.1.6-1
+    severity: high
+    summary: 'Pydantic v1 compatibility gap causes CLI plan tests to crash before execution.'
+    recommendation: 'Provide fallback definitions or pin pydantic>=2 so the plan discovery tests can exercise Browser-Use, HTTP, and Programmable Search flows.'
+
+waiver:
+  active: false
+
+quality_score: 45
+expires: '2025-12-09T00:00:00Z'
+
+evidence:
+  tests_reviewed: 1
+  risks_identified: 1
+  trace:
+    ac_covered: []
+    ac_gaps: [1, 2, 3, 4, 5, 6]
+    notes: 'Test suite aborts during import because ConfigDict is missing from pydantic; artifact persistence, guardrail logging, and discovery enrichment remain untested.'
+
+nfr_validation:
+  _assessed: [reliability, maintainability]
+  reliability:
+    status: FAIL
+    notes: 'Dependency regression blocks exercising Browser-Use run-store persistence and guardrail telemetry.'
+  maintainability:
+    status: WARN
+    notes: 'New CLI dependencies assume pydantic v2 types without compatibility shims, increasing upgrade friction.'
+
+recommendations:
+  immediate:
+    - 'Add a compatibility shim for ConfigDict (or require pydantic>=2) before re-running pytest apps/cli/tests/test_apply_plan.py -q.'
+  future:
+    - 'Backfill CI coverage for plan discovery across Browser-Use and Programmable Search once dependency constraints are resolved.'

--- a/docs/stories/4.1.6.lever-plan-browser-discovery.md
+++ b/docs/stories/4.1.6.lever-plan-browser-discovery.md
@@ -1,7 +1,7 @@
 # Story 4.1.6 — Lever Plan Browser Discovery
 
 ## Status
-Ready for dev
+QA Review — FAIL (pydantic v1 environment lacks ConfigDict guard; CLI plan tests abort)
 
 ## Story
 **As an** operator,
@@ -23,17 +23,23 @@ Ready for dev
 6. Automated tests cover all discovery modes: headless HTTP fetch, programmable search, and Browser-Use. API/crawl paths are mocked to avoid real Google traffic while asserting JSON structure, guardrail metadata, and artifact paths.
 
 ## Tasks / Subtasks
-- [ ] Extend CLI settings & profile schema to accept a `plan.browser_discovery` boolean (defaults to false for CI safety) and optional Programmable Search credentials (`plan.google_cse_key`, `plan.google_cse_cx`).
-- [ ] Add `_discover_candidates_with_browser()` helper that wires Browser-Use controller, guardrails, and SERP capture for Lever planning.
-- [ ] Add `_discover_candidates_with_cse()` helper that invokes the Google Custom Search JSON API when credentials are present, mapping responses to `LeverSerpResult` objects.
-- [ ] Update `apply plan` to resolve the discovery mode precedence (CSE when credentials exist and flag enabled, else Browser-Use when toggled, else HTTP fetch), persist artifacts, and enrich the plan payload with `results`.
-- [ ] Log guardrail changes and SERP capture outcomes (including API fallback results) to aid troubleshooting when Google presents CAPTCHAs or consent pages.
-- [ ] Write unit/CLI tests exercising all discovery modes (mock Browser-Use and CSE client) and document the new flags/credentials in README + story notes; update Epic 4 backlog.
+- [x] Extend CLI settings & profile schema to accept a `plan.browser_discovery` boolean (defaults to false for CI safety) and optional Programmable Search credentials (`plan.google_cse_key`, `plan.google_cse_cx`).
+- [x] Add `_discover_candidates_with_browser()` helper that wires Browser-Use controller, guardrails, and SERP capture for Lever planning.
+- [x] Add `_discover_candidates_with_cse()` helper that invokes the Google Custom Search JSON API when credentials are present, mapping responses to `LeverSerpResult` objects.
+- [x] Update `apply plan` to resolve the discovery mode precedence (CSE when credentials exist and flag enabled, else Browser-Use when toggled, else HTTP fetch), persist artifacts, and enrich the plan payload with `results`.
+- [x] Log guardrail changes and SERP capture outcomes (including API fallback results) to aid troubleshooting when Google presents CAPTCHAs or consent pages.
+- [x] Write unit/CLI tests exercising all discovery modes (mock Browser-Use and CSE client) and document the new flags/credentials in README + story notes; update Epic 4 backlog.
 
 ## Testing
-- Unit tests for Browser-Use discovery helper (SERP iteration, dedupe, artifact paths, guardrail payload).
-- CLI tests verifying `--browser-discovery` toggle and JSON output structure using mocked controller.
-- Regression run: `pytest sites/lever/tests -q` (existing coverage) plus new module tests.
+- `pytest apps/cli/tests/test_apply_plan.py -q`
+- `pytest sites/lever/tests -q`
+
+## QA Review Notes (2025-12-02)
+- Attempting to execute `pytest apps/cli/tests/test_apply_plan.py -q` fails during import because `apps/cli/profiles.py` requires `pydantic.ConfigDict`, which is unavailable in the installed pydantic v1.x runtime; the optional dependency guard only handles `ModuleNotFoundError`, so collection aborts before any Lever plan discovery assertions run. This blocks validation of Browser-Use, HTTP, and Programmable Search discovery paths.
+- Without the CLI plan test suite, none of the acceptance criteria covering artifact persistence, guardrail logging, or plan enrichment can be verified; the newly added discovery helpers remain untested in CI/QA environments pinned to pydantic v1.x.
+- Recommend updating the import guard to tolerate pydantic v1 deployments (e.g., fallback to stub definitions when `ConfigDict` is missing) or pinning pydantic>=2 in project requirements before requesting gate re-review.
+
+Gate tracking: docs/qa/gates/4.1.6-lever-plan-browser-discovery.yml (FAIL pending dependency compatibility fix).
 
 ## Dev Notes
 - Plan runs remain review-only; ensure Browser-Use sessions are launched in dry-run mode and terminate after capture.
@@ -52,3 +58,6 @@ Ready for dev
 | Date | Version | Description | Author |
 | --- | --- | --- | --- |
 | 2025-11-29 | 0.1 | Draft created to propose Browser-Use-backed Lever plan discovery. | Codex Agent |
+| 2025-12-01 | 1.0 | Implemented Browser-Use discovery + Programmable Search fallback with CLI/config flags, docs, and automated tests. | GPT-5 Codex |
+| 2025-12-01 | 1.1 | Added dependency guards for CLI plan tests, installed FastAPI/testclient deps, and executed regression suites. | GPT-5 Codex |
+| 2025-12-02 | 1.2 | QA review encountered pydantic v1 compatibility failure; pytest suite aborts before Lever plan discovery coverage, gate recorded as FAIL. | QA (Test Architect) |


### PR DESCRIPTION
## Summary
- document the QA review failure for story 4.1.6, noting pytest collection aborts caused by the missing `pydantic.ConfigDict` symbol in v1 environments and pointing to the new gate entry
- add a QA gate file capturing the dependency incompatibility, acceptance criteria gaps, and recommendations for restoring test coverage before re-review

## Testing
- pytest apps/cli/tests/test_apply_plan.py -q *(fails: ImportError: cannot import name 'ConfigDict' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68db1da1e72483249243d49ca3a8ecb9